### PR TITLE
Fix init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 -- Helper Lua file for easy require if tiny-ecs is used as a git submodule or
 -- folder. Not needed in many cases, including luarocks distribution.
 
-local directory = (...):match("(.-)[^%.]+$")
-return require(directory .. 'tiny')
+local args = {...}
+local directory = args[1]
+return require(directory .. '.tiny')


### PR DESCRIPTION
Fixes #18 

Allows `tiny-ecs` to be imported as a submodule.